### PR TITLE
[PRD-05] Add OAuth scope verification and re-auth-safe deploy flow

### DIFF
--- a/src/app/api/v1/deployments/[deployment_id]/retry/route.spec.ts
+++ b/src/app/api/v1/deployments/[deployment_id]/retry/route.spec.ts
@@ -5,16 +5,26 @@ import {
   DeploymentRetryAcceptedSchema,
   DeploymentStatusSchema
 } from "@/lib/contracts";
+import { REQUIRED_DEPLOYMENT_OAUTH_SCOPES } from "@/lib/server/deployments";
 
 import { POST as createDeployment } from "../../route";
 import { GET as getDeploymentStatus } from "../route";
 import { POST } from "./route";
 
+function buildAuthHeaders(): Record<string, string> {
+  return {
+    "x-user-id": "user-retry-route",
+    "x-oauth-token-status": "valid",
+    "x-oauth-scopes": [...REQUIRED_DEPLOYMENT_OAUTH_SCOPES].join(" ")
+  };
+}
+
 function buildCreateRequest(idempotency_key: string): Request {
   return new Request("http://localhost/api/v1/deployments", {
     method: "POST",
     headers: {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      ...buildAuthHeaders()
     },
     body: JSON.stringify({
       session_id: "sess-retry-route",
@@ -64,13 +74,17 @@ describe("POST /api/v1/deployments/{deployment_id}/retry", () => {
 
     for (let index = 0; index < 6; index += 1) {
       await getDeploymentStatus(
-        new Request("http://localhost"),
+        new Request("http://localhost", {
+          headers: buildAuthHeaders()
+        }),
         buildRouteContext(created.deployment_id)
       );
     }
 
     const failedResponse = await getDeploymentStatus(
-      new Request("http://localhost"),
+      new Request("http://localhost", {
+        headers: buildAuthHeaders()
+      }),
       buildRouteContext(created.deployment_id)
     );
     const failedPayload = DeploymentStatusSchema.parse(await failedResponse.json());
@@ -78,7 +92,10 @@ describe("POST /api/v1/deployments/{deployment_id}/retry", () => {
     expect(failedPayload.progress?.failed_step).toBe("Script");
 
     const retryResponse = await POST(
-      new Request("http://localhost", { method: "POST" }),
+      new Request("http://localhost", {
+        method: "POST",
+        headers: buildAuthHeaders()
+      }),
       buildRouteContext(created.deployment_id)
     );
 
@@ -95,7 +112,10 @@ describe("POST /api/v1/deployments/{deployment_id}/retry", () => {
     const created = DeploymentCreateAcceptedSchema.parse(await createResponse.json());
 
     const response = await POST(
-      new Request("http://localhost", { method: "POST" }),
+      new Request("http://localhost", {
+        method: "POST",
+        headers: buildAuthHeaders()
+      }),
       buildRouteContext(created.deployment_id)
     );
     const body = await response.json();

--- a/src/app/api/v1/deployments/[deployment_id]/retry/route.ts
+++ b/src/app/api/v1/deployments/[deployment_id]/retry/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 
-import { handleDeploymentRetry } from "@/lib/server/deployments";
+import {
+  getDeploymentAuthContextFromHeaders,
+  handleDeploymentRetry
+} from "@/lib/server/deployments";
 
 type RouteContext = {
   params: Promise<{
@@ -9,13 +12,14 @@ type RouteContext = {
 };
 
 export async function POST(
-  _request: Request,
+  request: Request,
   context: RouteContext
 ) {
   const { deployment_id } = await context.params;
 
   const result = handleDeploymentRetry({
-    deployment_id
+    deployment_id,
+    auth: getDeploymentAuthContextFromHeaders(request.headers)
   });
 
   return NextResponse.json(result.body, {

--- a/src/app/api/v1/deployments/[deployment_id]/route.spec.ts
+++ b/src/app/api/v1/deployments/[deployment_id]/route.spec.ts
@@ -1,15 +1,25 @@
 import { describe, expect, test } from "vitest";
 
 import { DeploymentCreateAcceptedSchema, DeploymentStatusSchema } from "@/lib/contracts";
+import { REQUIRED_DEPLOYMENT_OAUTH_SCOPES } from "@/lib/server/deployments";
 
 import { POST as createDeployment } from "../route";
 import { GET } from "./route";
+
+function buildAuthHeaders(): Record<string, string> {
+  return {
+    "x-user-id": "user-status-route",
+    "x-oauth-token-status": "valid",
+    "x-oauth-scopes": [...REQUIRED_DEPLOYMENT_OAUTH_SCOPES].join(" ")
+  };
+}
 
 function buildCreateRequest(idempotency_key: string): Request {
   return new Request("http://localhost/api/v1/deployments", {
     method: "POST",
     headers: {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      ...buildAuthHeaders()
     },
     body: JSON.stringify({
       session_id: "sess-status-route",
@@ -49,7 +59,9 @@ describe("GET /api/v1/deployments/{deployment_id}", () => {
     );
     const created = DeploymentCreateAcceptedSchema.parse(await createResponse.json());
 
-    const response = await GET(new Request("http://localhost"), {
+    const response = await GET(new Request("http://localhost", {
+      headers: buildAuthHeaders()
+    }), {
       params: Promise.resolve({
         deployment_id: created.deployment_id
       })
@@ -62,7 +74,9 @@ describe("GET /api/v1/deployments/{deployment_id}", () => {
   });
 
   test("returns NOT_FOUND for unknown deployment id", async () => {
-    const response = await GET(new Request("http://localhost"), {
+    const response = await GET(new Request("http://localhost", {
+      headers: buildAuthHeaders()
+    }), {
       params: Promise.resolve({
         deployment_id: "dep-missing-status"
       })

--- a/src/app/api/v1/deployments/[deployment_id]/route.ts
+++ b/src/app/api/v1/deployments/[deployment_id]/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 
-import { handleDeploymentStatus } from "@/lib/server/deployments";
+import {
+  getDeploymentAuthContextFromHeaders,
+  handleDeploymentStatus
+} from "@/lib/server/deployments";
 
 type RouteContext = {
   params: Promise<{
@@ -9,13 +12,14 @@ type RouteContext = {
 };
 
 export async function GET(
-  _request: Request,
+  request: Request,
   context: RouteContext
 ) {
   const { deployment_id } = await context.params;
 
   const result = handleDeploymentStatus({
-    deployment_id
+    deployment_id,
+    auth: getDeploymentAuthContextFromHeaders(request.headers)
   });
 
   return NextResponse.json(result.body, {

--- a/src/app/api/v1/deployments/route.spec.ts
+++ b/src/app/api/v1/deployments/route.spec.ts
@@ -1,14 +1,35 @@
 import { describe, expect, test } from "vitest";
 
 import { DeploymentCreateAcceptedSchema } from "@/lib/contracts";
+import { REQUIRED_DEPLOYMENT_OAUTH_SCOPES } from "@/lib/server/deployments";
 
 import { POST } from "./route";
 
-function buildRequest(payload: unknown): Request {
+function buildAuthHeaders(
+  overrides?: Partial<{
+    user_id: string;
+    oauth_token_status: "valid" | "missing" | "expired";
+    oauth_scopes: string[];
+  }>
+): Record<string, string> {
+  return {
+    "x-user-id": overrides?.user_id ?? "user-route-1",
+    "x-oauth-token-status": overrides?.oauth_token_status ?? "valid",
+    "x-oauth-scopes": (overrides?.oauth_scopes ?? [
+      ...REQUIRED_DEPLOYMENT_OAUTH_SCOPES
+    ]).join(" ")
+  };
+}
+
+function buildRequest(
+  payload: unknown,
+  authOverrides?: Parameters<typeof buildAuthHeaders>[0]
+): Request {
   return new Request("http://localhost/api/v1/deployments", {
     method: "POST",
     headers: {
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      ...buildAuthHeaders(authOverrides)
     },
     body: JSON.stringify(payload)
   });
@@ -91,5 +112,26 @@ describe("POST /api/v1/deployments", () => {
     expect(response.status).toBe(409);
     expect(body.error.code).toBe("CONFLICT");
   });
-});
 
+  test("returns recoverable UNAUTHORIZED and supports resume after re-auth", async () => {
+    const payload = buildReadyPayload("route-reauth-resume-v1");
+
+    const blocked = await POST(
+      buildRequest(payload, {
+        oauth_token_status: "expired"
+      })
+    );
+    const blockedBody = await blocked.json();
+    expect(blocked.status).toBe(401);
+    expect(blockedBody.error.code).toBe("UNAUTHORIZED");
+    expect(blockedBody.error.retryable).toBe(true);
+    expect(blockedBody.error.details.reason).toBe("expired_oauth_token");
+    expect(blockedBody.error.details.resume_context).toEqual({
+      session_id: payload.session_id,
+      idempotency_key: payload.idempotency_key
+    });
+
+    const resumed = await POST(buildRequest(payload));
+    expect(resumed.status).toBe(202);
+  });
+});

--- a/src/app/api/v1/deployments/route.ts
+++ b/src/app/api/v1/deployments/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
 
 import {
+  getDeploymentAuthContextFromHeaders,
   handleDeployments
 } from "@/lib/server/deployments";
 
 export async function POST(request: Request) {
   try {
     const result = handleDeployments({
-      rawBody: await request.json()
+      rawBody: await request.json(),
+      auth: getDeploymentAuthContextFromHeaders(request.headers)
     });
 
     return NextResponse.json(result.body, {
@@ -25,4 +27,3 @@ export async function POST(request: Request) {
     );
   }
 }
-

--- a/src/lib/server/deployments/__tests__/auth.spec.ts
+++ b/src/lib/server/deployments/__tests__/auth.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  getDeploymentAuthContextFromHeaders,
+  guardDeploymentAuth,
+  REQUIRED_DEPLOYMENT_OAUTH_SCOPES
+} from "@/lib/server/deployments/auth";
+
+describe("deployment auth guard", () => {
+  test("returns UNAUTHORIZED when user_id is missing", () => {
+    const result = guardDeploymentAuth({
+      context: {
+        user_id: null,
+        oauth_token_status: "valid",
+        oauth_scopes: [...REQUIRED_DEPLOYMENT_OAUTH_SCOPES]
+      },
+      resume_context: {
+        session_id: "sess-1",
+        idempotency_key: "idem-1"
+      }
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "UNAUTHORIZED",
+      retryable: false,
+      details: {
+        reason: "missing_user_id",
+        resume_context: {
+          session_id: "sess-1",
+          idempotency_key: "idem-1"
+        }
+      }
+    });
+  });
+
+  test("returns recoverable UNAUTHORIZED when required scopes are missing", () => {
+    const result = guardDeploymentAuth({
+      context: {
+        user_id: "user-1",
+        oauth_token_status: "valid",
+        oauth_scopes: [REQUIRED_DEPLOYMENT_OAUTH_SCOPES[0]]
+      },
+      resume_context: {
+        session_id: "sess-1",
+        idempotency_key: "idem-1"
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected auth to fail");
+    }
+
+    expect(result.code).toBe("UNAUTHORIZED");
+    expect(result.retryable).toBe(true);
+    expect(result.details.reason).toBe("missing_required_scopes");
+    expect(result.details.reauth_required).toBe(true);
+    expect(result.details.missing_scopes).toEqual(
+      REQUIRED_DEPLOYMENT_OAUTH_SCOPES.slice(1)
+    );
+  });
+
+  test("returns recoverable UNAUTHORIZED when token is expired", () => {
+    const result = guardDeploymentAuth({
+      context: {
+        user_id: "user-1",
+        oauth_token_status: "expired",
+        oauth_scopes: [...REQUIRED_DEPLOYMENT_OAUTH_SCOPES]
+      },
+      resume_context: {
+        session_id: "sess-1",
+        idempotency_key: "idem-1"
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected auth to fail");
+    }
+
+    expect(result.code).toBe("UNAUTHORIZED");
+    expect(result.retryable).toBe(true);
+    expect(result.details.reason).toBe("expired_oauth_token");
+    expect(result.details.reauth_required).toBe(true);
+    expect(result.details.resume_context).toEqual({
+      session_id: "sess-1",
+      idempotency_key: "idem-1"
+    });
+  });
+
+  test("returns success when user and scopes satisfy requirements", () => {
+    const result = guardDeploymentAuth({
+      context: {
+        user_id: " user-1 ",
+        oauth_token_status: "valid",
+        oauth_scopes: [...REQUIRED_DEPLOYMENT_OAUTH_SCOPES]
+      },
+      resume_context: {
+        session_id: "sess-1",
+        idempotency_key: "idem-1"
+      }
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      user_id: "user-1",
+      required_scopes: [...REQUIRED_DEPLOYMENT_OAUTH_SCOPES],
+      granted_scopes: [...REQUIRED_DEPLOYMENT_OAUTH_SCOPES]
+    });
+  });
+});
+
+describe("deployment auth header parsing", () => {
+  test("builds auth context from user, token status, and mixed scope separators", () => {
+    const headers = new Headers({
+      "x-user-id": " user-2 ",
+      "x-oauth-token-status": "valid",
+      "x-oauth-scopes": `${REQUIRED_DEPLOYMENT_OAUTH_SCOPES[0]}, ${REQUIRED_DEPLOYMENT_OAUTH_SCOPES[1]}`
+    });
+
+    const context = getDeploymentAuthContextFromHeaders(headers);
+    expect(context).toEqual({
+      user_id: "user-2",
+      oauth_token_status: "valid",
+      oauth_scopes: [
+        REQUIRED_DEPLOYMENT_OAUTH_SCOPES[0],
+        REQUIRED_DEPLOYMENT_OAUTH_SCOPES[1]
+      ]
+    });
+  });
+});

--- a/src/lib/server/deployments/__tests__/handler.spec.ts
+++ b/src/lib/server/deployments/__tests__/handler.spec.ts
@@ -5,6 +5,10 @@ import {
   createDeploymentStatusHandler,
   createDeploymentsHandler
 } from "@/lib/server/deployments/handler";
+import {
+  REQUIRED_DEPLOYMENT_OAUTH_SCOPES,
+  type DeploymentAuthContext
+} from "@/lib/server/deployments/auth";
 import type { DeploymentsStore } from "@/lib/server/deployments/store";
 import {
   createInMemoryDeploymentsStore
@@ -41,6 +45,14 @@ function buildReadyPayload() {
   };
 }
 
+function buildAuthorizedAuthContext(): DeploymentAuthContext {
+  return {
+    user_id: "user-123",
+    oauth_token_status: "valid",
+    oauth_scopes: [...REQUIRED_DEPLOYMENT_OAUTH_SCOPES]
+  };
+}
+
 describe("deployments create handler", () => {
   test("returns INVALID_SCHEMA for invalid payload", () => {
     const handler = createDeploymentsHandler({
@@ -52,7 +64,8 @@ describe("deployments create handler", () => {
       rawBody: {
         session_id: "",
         idempotency_key: ""
-      }
+      },
+      auth: buildAuthorizedAuthContext()
     });
 
     expect(result.status).toBe(400);
@@ -69,7 +82,8 @@ describe("deployments create handler", () => {
     payload.assistant_snapshot.deploy_readiness_reasons = ["Critical unresolved questions remain."];
 
     const result = handler({
-      rawBody: payload
+      rawBody: payload,
+      auth: buildAuthorizedAuthContext()
     });
 
     expect(result.status).toBe(409);
@@ -86,7 +100,8 @@ describe("deployments create handler", () => {
     });
 
     const result = handler({
-      rawBody: buildReadyPayload()
+      rawBody: buildReadyPayload(),
+      auth: buildAuthorizedAuthContext()
     });
 
     expect(result.status).toBe(202);
@@ -104,10 +119,12 @@ describe("deployments create handler", () => {
     const payload = buildReadyPayload();
 
     const first = handler({
-      rawBody: payload
+      rawBody: payload,
+      auth: buildAuthorizedAuthContext()
     });
     const replay = handler({
-      rawBody: payload
+      rawBody: payload,
+      auth: buildAuthorizedAuthContext()
     });
 
     expect(first.status).toBe(202);
@@ -127,10 +144,12 @@ describe("deployments create handler", () => {
     secondPayload.assistant_snapshot.confidence = 0.77;
 
     handler({
-      rawBody: firstPayload
+      rawBody: firstPayload,
+      auth: buildAuthorizedAuthContext()
     });
     const conflict = handler({
-      rawBody: secondPayload
+      rawBody: secondPayload,
+      auth: buildAuthorizedAuthContext()
     });
 
     expect(conflict.status).toBe(409);
@@ -138,6 +157,62 @@ describe("deployments create handler", () => {
     expect(conflict.body.error.details.reason).toBe(
       "idempotency_key_reused_with_different_payload"
     );
+  });
+
+  test("returns recoverable UNAUTHORIZED when required scopes are missing", () => {
+    const handler = createDeploymentsHandler({
+      store: createInMemoryDeploymentsStore(),
+      requestIdFactory: () => "req-auth-scopes"
+    });
+    const payload = buildReadyPayload();
+
+    const result = handler({
+      rawBody: payload,
+      auth: {
+        user_id: "user-123",
+        oauth_token_status: "valid",
+        oauth_scopes: [REQUIRED_DEPLOYMENT_OAUTH_SCOPES[0]]
+      }
+    });
+
+    expect(result.status).toBe(401);
+    expect(result.body.error.code).toBe("UNAUTHORIZED");
+    expect(result.body.error.retryable).toBe(true);
+    expect(result.body.error.details.reason).toBe("missing_required_scopes");
+    expect(result.body.error.details.reauth_required).toBe(true);
+    expect(result.body.error.details.resume_context).toEqual({
+      session_id: payload.session_id,
+      idempotency_key: payload.idempotency_key
+    });
+  });
+
+  test("resumes deploy create successfully after re-auth with the same draft payload", () => {
+    const handler = createDeploymentsHandler({
+      store: createInMemoryDeploymentsStore(),
+      requestIdFactory: () => "req-auth-resume"
+    });
+    const payload = buildReadyPayload();
+
+    const blocked = handler({
+      rawBody: payload,
+      auth: {
+        user_id: "user-123",
+        oauth_token_status: "expired",
+        oauth_scopes: [...REQUIRED_DEPLOYMENT_OAUTH_SCOPES]
+      }
+    });
+    expect(blocked.status).toBe(401);
+    expect(blocked.body.error.code).toBe("UNAUTHORIZED");
+    expect(blocked.body.error.details.reason).toBe("expired_oauth_token");
+
+    const resumed = handler({
+      rawBody: payload,
+      auth: buildAuthorizedAuthContext()
+    });
+    expect(resumed.status).toBe(202);
+    if (resumed.status === 202) {
+      expect(resumed.body.status).toBe("queued");
+    }
   });
 });
 
@@ -149,7 +224,8 @@ describe("deployments status and retry handlers", () => {
     });
 
     const result = statusHandler({
-      deployment_id: "missing-id"
+      deployment_id: "missing-id",
+      auth: buildAuthorizedAuthContext()
     });
 
     expect(result.status).toBe(404);
@@ -168,14 +244,16 @@ describe("deployments status and retry handlers", () => {
     });
 
     const created = createHandler({
-      rawBody: buildReadyPayload()
+      rawBody: buildReadyPayload(),
+      auth: buildAuthorizedAuthContext()
     });
     if (created.status !== 202) {
       throw new Error("Expected deployment creation to succeed");
     }
 
     const firstPoll = statusHandler({
-      deployment_id: created.body.deployment_id
+      deployment_id: created.body.deployment_id,
+      auth: buildAuthorizedAuthContext()
     });
     expect(firstPoll.status).toBe(200);
     if (firstPoll.status === 200) {
@@ -186,7 +264,8 @@ describe("deployments status and retry handlers", () => {
     let latest = firstPoll;
     for (let index = 0; index < 5; index += 1) {
       latest = statusHandler({
-        deployment_id: created.body.deployment_id
+        deployment_id: created.body.deployment_id,
+        auth: buildAuthorizedAuthContext()
       });
     }
 
@@ -215,14 +294,16 @@ describe("deployments status and retry handlers", () => {
     });
 
     const created = createHandler({
-      rawBody: buildReadyPayload()
+      rawBody: buildReadyPayload(),
+      auth: buildAuthorizedAuthContext()
     });
     if (created.status !== 202) {
       throw new Error("Expected deployment creation to succeed");
     }
 
     const retry = retryHandler({
-      deployment_id: created.body.deployment_id
+      deployment_id: created.body.deployment_id,
+      auth: buildAuthorizedAuthContext()
     });
     expect(retry.status).toBe(409);
     expect(retry.body.error.code).toBe("CONFLICT");
@@ -247,7 +328,8 @@ describe("deployments status and retry handlers", () => {
     const payload = buildReadyPayload();
     payload.idempotency_key = "deploy-sess-123-fail-once-v1";
     const created = createHandler({
-      rawBody: payload
+      rawBody: payload,
+      auth: buildAuthorizedAuthContext()
     });
     if (created.status !== 202) {
       throw new Error("Expected deployment creation to succeed");
@@ -255,12 +337,14 @@ describe("deployments status and retry handlers", () => {
 
     for (let index = 0; index < 5; index += 1) {
       statusHandler({
-        deployment_id: created.body.deployment_id
+        deployment_id: created.body.deployment_id,
+        auth: buildAuthorizedAuthContext()
       });
     }
 
     const failed = statusHandler({
-      deployment_id: created.body.deployment_id
+      deployment_id: created.body.deployment_id,
+      auth: buildAuthorizedAuthContext()
     });
     expect(failed.status).toBe(200);
     if (failed.status === 200) {
@@ -269,7 +353,8 @@ describe("deployments status and retry handlers", () => {
     }
 
     const retried = retryHandler({
-      deployment_id: created.body.deployment_id
+      deployment_id: created.body.deployment_id,
+      auth: buildAuthorizedAuthContext()
     });
     expect(retried.status).toBe(202);
     if (retried.status === 202) {
@@ -301,7 +386,8 @@ describe("deployments handlers internal errors", () => {
     });
 
     const result = handler({
-      rawBody: buildReadyPayload()
+      rawBody: buildReadyPayload(),
+      auth: buildAuthorizedAuthContext()
     });
 
     expect(result.status).toBe(500);
@@ -316,7 +402,8 @@ describe("deployments handlers internal errors", () => {
     });
 
     const result = handler({
-      deployment_id: "dep-1"
+      deployment_id: "dep-1",
+      auth: buildAuthorizedAuthContext()
     });
 
     expect(result.status).toBe(500);
@@ -330,7 +417,8 @@ describe("deployments handlers internal errors", () => {
     });
 
     const result = handler({
-      deployment_id: "dep-1"
+      deployment_id: "dep-1",
+      auth: buildAuthorizedAuthContext()
     });
 
     expect(result.status).toBe(500);

--- a/src/lib/server/deployments/auth.ts
+++ b/src/lib/server/deployments/auth.ts
@@ -1,0 +1,201 @@
+export const REQUIRED_DEPLOYMENT_OAUTH_SCOPES = Object.freeze([
+  "https://www.googleapis.com/auth/forms.body",
+  "https://www.googleapis.com/auth/spreadsheets",
+  "https://www.googleapis.com/auth/drive.file",
+  "https://www.googleapis.com/auth/script.projects"
+] as const);
+
+export type DeploymentOAuthTokenStatus = "valid" | "missing" | "expired";
+
+export type DeploymentAuthContext = {
+  user_id: string | null;
+  oauth_token_status: DeploymentOAuthTokenStatus;
+  oauth_scopes: string[];
+};
+
+export type DeploymentResumeContext = {
+  session_id?: string;
+  idempotency_key?: string;
+  deployment_id?: string;
+};
+
+type MissingUserIdAuthResult = {
+  ok: false;
+  code: "UNAUTHORIZED";
+  retryable: false;
+  details: {
+    reason: "missing_user_id";
+    resume_context: DeploymentResumeContext;
+  };
+};
+
+type RecoverableOAuthAuthResult = {
+  ok: false;
+  code: "UNAUTHORIZED";
+  retryable: true;
+  details: {
+    reason:
+      | "missing_oauth_token"
+      | "expired_oauth_token"
+      | "missing_required_scopes";
+    reauth_required: true;
+    required_scopes: string[];
+    granted_scopes: string[];
+    missing_scopes: string[];
+    resume_context: DeploymentResumeContext;
+  };
+};
+
+type DeploymentAuthSuccessResult = {
+  ok: true;
+  user_id: string;
+  required_scopes: string[];
+  granted_scopes: string[];
+};
+
+export type GuardDeploymentAuthResult =
+  | MissingUserIdAuthResult
+  | RecoverableOAuthAuthResult
+  | DeploymentAuthSuccessResult;
+
+type GuardDeploymentAuthInput = {
+  context: DeploymentAuthContext;
+  resume_context: DeploymentResumeContext;
+  required_scopes?: readonly string[];
+};
+
+function normalizeScopes(scopes: readonly string[]): string[] {
+  const normalized = scopes
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+
+  return [...new Set(normalized)];
+}
+
+function parseOAuthScopes(rawScopes: string | null): string[] {
+  if (!rawScopes) {
+    return [];
+  }
+
+  return normalizeScopes(rawScopes.split(/[,\s]+/u));
+}
+
+function buildRecoverableOAuthError(
+  reason:
+    | "missing_oauth_token"
+    | "expired_oauth_token"
+    | "missing_required_scopes",
+  required_scopes: string[],
+  granted_scopes: string[],
+  missing_scopes: string[],
+  resume_context: DeploymentResumeContext
+): RecoverableOAuthAuthResult {
+  return {
+    ok: false,
+    code: "UNAUTHORIZED",
+    retryable: true,
+    details: {
+      reason,
+      reauth_required: true,
+      required_scopes,
+      granted_scopes,
+      missing_scopes,
+      resume_context
+    }
+  };
+}
+
+export function guardDeploymentAuth(
+  input: GuardDeploymentAuthInput
+): GuardDeploymentAuthResult {
+  const user_id = input.context.user_id?.trim();
+  const required_scopes = normalizeScopes(
+    input.required_scopes ?? REQUIRED_DEPLOYMENT_OAUTH_SCOPES
+  );
+  const granted_scopes = normalizeScopes(input.context.oauth_scopes);
+
+  if (!user_id) {
+    return {
+      ok: false,
+      code: "UNAUTHORIZED",
+      retryable: false,
+      details: {
+        reason: "missing_user_id",
+        resume_context: input.resume_context
+      }
+    };
+  }
+
+  if (input.context.oauth_token_status === "missing") {
+    return buildRecoverableOAuthError(
+      "missing_oauth_token",
+      required_scopes,
+      granted_scopes,
+      required_scopes,
+      input.resume_context
+    );
+  }
+
+  if (input.context.oauth_token_status === "expired") {
+    return buildRecoverableOAuthError(
+      "expired_oauth_token",
+      required_scopes,
+      granted_scopes,
+      required_scopes,
+      input.resume_context
+    );
+  }
+
+  const grantedScopeSet = new Set(granted_scopes);
+  const missing_scopes = required_scopes.filter(
+    (scope) => !grantedScopeSet.has(scope)
+  );
+
+  if (missing_scopes.length > 0) {
+    return buildRecoverableOAuthError(
+      "missing_required_scopes",
+      required_scopes,
+      granted_scopes,
+      missing_scopes,
+      input.resume_context
+    );
+  }
+
+  return {
+    ok: true,
+    user_id,
+    required_scopes,
+    granted_scopes
+  };
+}
+
+function parseOAuthTokenStatus(
+  input: string | null
+): DeploymentOAuthTokenStatus | null {
+  const normalized = input?.trim().toLowerCase();
+  if (
+    normalized === "valid" ||
+    normalized === "missing" ||
+    normalized === "expired"
+  ) {
+    return normalized;
+  }
+
+  return null;
+}
+
+export function getDeploymentAuthContextFromHeaders(
+  headers: Headers
+): DeploymentAuthContext {
+  const user_id = headers.get("x-user-id")?.trim() ?? "";
+  const parsedTokenStatus = parseOAuthTokenStatus(
+    headers.get("x-oauth-token-status")
+  );
+
+  return {
+    user_id: user_id.length > 0 ? user_id : null,
+    oauth_token_status:
+      parsedTokenStatus ?? (user_id.length > 0 ? "valid" : "missing"),
+    oauth_scopes: parseOAuthScopes(headers.get("x-oauth-scopes"))
+  };
+}

--- a/src/lib/server/deployments/handler.ts
+++ b/src/lib/server/deployments/handler.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { DeploymentStatusSchema, type DeploymentStatus } from "@/lib/contracts";
 import { createApiErrorResponse, type ApiErrorResponseBody } from "@/lib/errors";
 
+import { guardDeploymentAuth, type DeploymentAuthContext } from "./auth";
 import { toCanonicalJson } from "./hash";
 import {
   type DeploymentCreateAccepted,
@@ -27,6 +28,7 @@ export interface DeploymentsHandlerDependencies {
 
 export interface DeploymentsHandlerInput {
   rawBody: unknown;
+  auth: DeploymentAuthContext;
 }
 
 export type DeploymentsHandlerSuccessResult = {
@@ -45,6 +47,7 @@ export type DeploymentsHandlerResult =
 
 export interface DeploymentStatusHandlerInput {
   deployment_id: string;
+  auth: DeploymentAuthContext;
 }
 
 export type DeploymentStatusHandlerSuccessResult = {
@@ -58,6 +61,7 @@ export type DeploymentStatusHandlerResult =
 
 export interface DeploymentRetryHandlerInput {
   deployment_id: string;
+  auth: DeploymentAuthContext;
 }
 
 export type DeploymentRetryHandlerSuccessResult = {
@@ -71,18 +75,21 @@ export type DeploymentRetryHandlerResult =
 
 function buildError(
   code:
+    | "UNAUTHORIZED"
     | "INVALID_SCHEMA"
     | "DEPLOY_NOT_READY"
     | "CONFLICT"
     | "NOT_FOUND"
     | "INTERNAL_ERROR",
   request_id: string,
-  details: Record<string, unknown>
+  details: Record<string, unknown>,
+  retryable?: boolean
 ): DeploymentsHandlerErrorResult {
   return createApiErrorResponse({
     code,
     request_id,
-    details
+    details,
+    retryable
   });
 }
 
@@ -116,6 +123,22 @@ export function createDeploymentsHandler(dependencies: DeploymentsHandlerDepende
 
     try {
       const request = parsedRequest.data;
+      const authResult = guardDeploymentAuth({
+        context: input.auth,
+        resume_context: {
+          session_id: request.session_id,
+          idempotency_key: request.idempotency_key
+        }
+      });
+      if (!authResult.ok) {
+        return buildError(
+          authResult.code,
+          request_id,
+          authResult.details,
+          authResult.retryable
+        );
+      }
+
       if (!request.assistant_snapshot.deploy_ready) {
         return buildError("DEPLOY_NOT_READY", request_id, {
           session_id: request.session_id,
@@ -174,6 +197,21 @@ export function createDeploymentStatusHandler(
     }
 
     try {
+      const authResult = guardDeploymentAuth({
+        context: input.auth,
+        resume_context: {
+          deployment_id: input.deployment_id
+        }
+      });
+      if (!authResult.ok) {
+        return buildError(
+          authResult.code,
+          request_id,
+          authResult.details,
+          authResult.retryable
+        );
+      }
+
       const deployment = dependencies.store.advanceDeployment(input.deployment_id);
       if (!deployment) {
         return buildError("NOT_FOUND", request_id, {
@@ -213,6 +251,21 @@ export function createDeploymentRetryHandler(
     }
 
     try {
+      const authResult = guardDeploymentAuth({
+        context: input.auth,
+        resume_context: {
+          deployment_id: input.deployment_id
+        }
+      });
+      if (!authResult.ok) {
+        return buildError(
+          authResult.code,
+          request_id,
+          authResult.details,
+          authResult.retryable
+        );
+      }
+
       const result = dependencies.store.retryDeployment(input.deployment_id);
 
       if (result.kind === "not_found") {

--- a/src/lib/server/deployments/index.ts
+++ b/src/lib/server/deployments/index.ts
@@ -1,4 +1,4 @@
+export * from "./auth";
 export * from "./handler";
 export * from "./schemas";
 export * from "./store";
-


### PR DESCRIPTION
## Summary
- add deployment OAuth auth guard with required Google scopes (Forms, Sheets, Drive, Apps Script)
- return recoverable UNAUTHORIZED errors for missing or expired token and missing scopes, including resume_context
- wire auth context parsing from request headers into deployments create/status/retry routes
- add handler and route tests for scope failures and resume path after re-auth

## Validation
- pnpm test

Closes #27